### PR TITLE
Add link to Overleaf template

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,7 +198,7 @@
         conference in mid-November. To submit to the conference, please download the
         LaTeX template files (<a href="resources/anthology-ch.zip">anthology-ch.zip</a>)
         or use the pre-created Overleaf template available here:
-        <a href="#">overleaf template</a>. We will provide a similar template
+        <a href="https://www.overleaf.com/latex/templates/ach-proceedings-paper-template/znmzmfngrwpd">overleaf template</a>. We will provide a similar template
         for other conference proceedings in additional formats (e.g., markdown)
         as needed.
       </p>


### PR DESCRIPTION
The link to the Overleaf repository was not set; this is the one I found by searching the Overleaf templates.