### PR TITLE
Minor changes to anthology cls based on author feedback

### DIFF
--- a/resources/anthology-ch-all/anthology-ch.cls
+++ b/resources/anthology-ch-all/anthology-ch.cls
@@ -6,6 +6,9 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % WORK OFF OF THE BASE ARTICLE CLASS
 \LoadClass[11pt]{article}
+\AtBeginDocument{%
+  \emergencystretch 2em
+}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % LOAD ALL REQUIRED PACKAGES HERE
@@ -392,6 +395,7 @@
   style=numeric,
   giveninits=false,
   sortcites=true,
+  maxbibnames=10,
   backend=biber]{biblatex}
 \if@fra
   \RequirePackage[english, french]{babel}
@@ -432,6 +436,12 @@
 \DeclareFieldFormat[article]{journaltitle}{\mkbibemph{#1}}
 
 % Format volume and issue numbers according to MLA
+\renewbibmacro*{volume+number+eid}{%
+  \printfield{volume}%
+  \setunit*{}% <-- no dot/comma here; number format already adds ", no. "
+  \printfield{number}%
+  \setunit{\addcomma\space}%
+  \printfield{eid}}
 \DeclareFieldFormat[article]{volume}{\mkbibemph{#1}}
 \DeclareFieldFormat[article]{number}{, no. #1}
 


### PR DESCRIPTION
I added `\emergencystretch 2em` at the top because some authors were facing an issue where lines were exceeding the margins of the paper. This makes things a bit looser. 

I added `maxbibnames=10,` because in previous years, we preferred avoiding `et al.` in author lists in the bibliography, the template we shared unfortunately abbreviates all author lists that are longer than ~3 authors. This makes it so that author lists are only abbreviated if they are overly long (e.g. some language model papers have a gazillion authors). 

I added the snippet involving `\renewbibmacro*{volume+number+eid}` because an author noted that journal names sometimes had an unnecessary period after the journal title in the bibliography: 

> Kestemont, Mike, Daelemans, Walter, and Sandra, Dominiek. “Robust rhymes? The stability
of authorial style in medieval narratives.” In: _Journal of Quantitative Linguistics 19_., no.
1 (2012), pp. 54–76.

The proposed change results instead in: 

> Kestemont, Mike, Daelemans, Walter, and Sandra, Dominiek. “Robust rhymes? The stability
of authorial style in medieval narratives.” In: _Journal of Quantitative Linguistics 19_, no.
1 (2012), pp. 54–76.

Something we could consider amending further is to include "vol." in the bibliography format to better match [Purdue's MLA guidelines](https://owl.purdue.edu/owl/research_and_citation/mla_style/mla_formatting_and_style_guide/mla_works_cited_periodicals.html) -- let me know if you would want this! 

Another observation: our camera ready submissions checklist suggests XeLaTeX as the compiler. When some authors switch from pdfLaTeX to XeLaTeX as their compiler, their hyphens disappear from the text. One fix is to retype all hyphens in the paper, but it's possible some authors may miss this error when they submit. In the future, we should specify XeLaTeX as the default compiler at the template-sharing stage of the conference cycle. 