### PR TITLE
Fix broken volume links 

### DIFF
--- a/volumes/index.html
+++ b/volumes/index.html
@@ -56,7 +56,7 @@
       <ul>
         
           <li>
-            <a href="volumes/vol0001/" class="toc-link">
+            <a href="/volumes/vol0001/" class="toc-link">
               <b>Volume 1: —</b>
               <span class="icon is-small">
                 <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12"
@@ -75,7 +75,7 @@
           </li>
         
           <li>
-            <a href="volumes/vol0002/" class="toc-link">
+            <a href="/volumes/vol0002/" class="toc-link">
               <b>Volume 2: Digital Humanities Tech Symposium 2025</b>
               <span class="icon is-small">
                 <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12"


### PR DESCRIPTION
@taylor-arnold : The volume links on the volume index page on the published site are currently resulting in a 404 because they are relative links, which results in `/volumes/volumes/vol0001/`

My proposed change makes the links absolute, as a quick fix. (I presume these are autogenerated, so you may need to tweak something in your last set of changes)