### PR TITLE
Fix Placeholder Link

### DIFF
--- a/docs/volumes/vol0003/seeing-history-unseen-evaluating-vision-language/paper.tex
+++ b/docs/volumes/vol0003/seeing-history-unseen-evaluating-vision-language/paper.tex
@@ -775,7 +775,7 @@ All code, datasets, and analysis artefacts supporting this study are openly avai
 
 \textbf{Repository:} \url{https://github.com/maehr/chr2025-seeing-history-unseen}
 
-\textbf{Persistent record:} \href{https://doi.org/XXXX}{FIXME Zenodo DOI}
+\textbf{Persistent record:} \href{https://doi.org/10.5281/zenodo.17639517}{DOI 10.5281/zenodo.17639517}
 
 The repository provides a complete, executable research pipeline for the CHR 2025 paper \emph{“Seeing History Unseen: Evaluating Vision-Language Models for WCAG-Compliant Alt-Text in Digital Heritage Collections.”}
 


### PR DESCRIPTION
As mentioned in #10, we left a placeholder value in our final paper. This PR adds the actual link to Zenodo where the content has been published in the meantime.

In line with the other PRs I found here, I'm just pushing the updated `.tex` file without having re-compiled the volume itself.

Best regards
Moritz